### PR TITLE
Peg max78000 dependency to a tag

### DIFF
--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 [dependencies]
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
 heapless = "0.7.16"
-max78000 = { git = "ssh://git@github.com/SlugSecurity/max78000.git", features = ["critical-section"] }
+max78000 = { git = "ssh://git@github.com/SlugSecurity/max78000.git", features = ["critical-section"], tag = "v0.1.0" }
 
 [features]
 rt = ["max78000/rt"]


### PR DESCRIPTION
Pegs `max78000` crate dependency to a tag for `v0.1.0` so that we can maintain compatibility with breaking updates from the upstream SVD or svd2rust. 