### PR TITLE
FLC Rework

### DIFF
--- a/hal/src/peripherals/flash_controller.rs
+++ b/hal/src/peripherals/flash_controller.rs
@@ -138,11 +138,7 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
     ///  - Lock write protection
     ///  - Flush ICC
     ///  - Enable icc0
-    fn write_guard<F: Fn()>(
-        &self,
-        sys_clk: &SystemClock,
-        operation: F,
-    ) -> Result<(), FlashErr> {
+    fn write_guard<F: Fn()>(&self, sys_clk: &SystemClock, operation: F) -> Result<(), FlashErr> {
         // Pre-write
         self.wait_until_ready();
         self.disable_icc0();

--- a/hal/src/peripherals/flash_controller.rs
+++ b/hal/src/peripherals/flash_controller.rs
@@ -242,8 +242,7 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
         Ok(())
     }
 
-    ///
-    /// # Safety
+    /// SAFETY:
     ///
     /// Writes must not corrupt potentially executable instructions of the program.
     /// Callers must ensure that the following condition is met:
@@ -303,7 +302,7 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
     /// Data needs to fit within one flash word (16 bytes).
     ///
     /// SAFETY:
-    /// 
+    ///
     /// Writes must not corrupt potentially executable instructions of the program.
     /// Callers must ensure that the following condition is met:
     /// * If `address` points to a portion of the program's instructions, `data` must
@@ -346,7 +345,7 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
     /// Address must be 128-bit aligned.
     ///
     /// SAFETY:
-    /// 
+    ///
     /// Writes must not corrupt potentially executable instructions of the program.
     /// Callers must ensure that the following condition is met:
     /// * If `address` points to a portion of the program's instructions, `data` must

--- a/hal/src/peripherals/flash_controller.rs
+++ b/hal/src/peripherals/flash_controller.rs
@@ -299,8 +299,19 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
         Ok(())
     }
 
-    /// Writes less than 128 bits (16 bytes) of data to flash. Data needs to fit
-    /// within one flash word (16 bytes).
+    /// Writes less than 128 bits (16 bytes) of data to flash.
+    /// Data needs to fit within one flash word (16 bytes).
+    ///
+    /// SAFETY:
+    /// 
+    /// Writes must not corrupt potentially executable instructions of the program.
+    /// Callers must ensure that the following condition is met:
+    /// * If `address` points to a portion of the program's instructions, `data` must
+    ///   contain valid instructions that does not introduce undefined behavior.
+    ///
+    /// It is very difficult to define what would cause undefined behavior when
+    /// modifying program instructions. This would almost certainly result
+    /// in unwanted and likely undefined behavior. Do so at your own risk.
     unsafe fn write_lt_128_unaligned(
         &self,
         address: u32,
@@ -332,6 +343,18 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
     }
 
     /// Writes 128 bits (16 bytes) of data to flash.
+    /// Address must be 128-bit aligned.
+    ///
+    /// SAFETY:
+    /// 
+    /// Writes must not corrupt potentially executable instructions of the program.
+    /// Callers must ensure that the following condition is met:
+    /// * If `address` points to a portion of the program's instructions, `data` must
+    ///   contain valid instructions that does not introduce undefined behavior.
+    ///
+    /// It is very difficult to define what would cause undefined behavior when
+    /// modifying program instructions. This would almost certainly result
+    /// in unwanted and likely undefined behavior. Do so at your own risk.
     unsafe fn write128(
         &self,
         address: u32,

--- a/hal/src/peripherals/flash_controller.rs
+++ b/hal/src/peripherals/flash_controller.rs
@@ -242,7 +242,7 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
         Ok(())
     }
 
-    /// SAFETY:
+    /// # Safety
     ///
     /// Writes must not corrupt potentially executable instructions of the program.
     /// Callers must ensure that the following condition is met:
@@ -301,7 +301,7 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
     /// Writes less than 128 bits (16 bytes) of data to flash.
     /// Data needs to fit within one flash word (16 bytes).
     ///
-    /// SAFETY:
+    /// # Safety
     ///
     /// Writes must not corrupt potentially executable instructions of the program.
     /// Callers must ensure that the following condition is met:
@@ -344,7 +344,7 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
     /// Writes 128 bits (16 bytes) of data to flash.
     /// Address must be 128-bit aligned.
     ///
-    /// SAFETY:
+    /// # Safety
     ///
     /// Writes must not corrupt potentially executable instructions of the program.
     /// Callers must ensure that the following condition is met:

--- a/hal/src/peripherals/flash_controller.rs
+++ b/hal/src/peripherals/flash_controller.rs
@@ -112,21 +112,21 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
     }
 
     /// Busy loop until FLC is ready.
-    /// 
+    ///
     /// This MUST be called BEFORE any FLC operation EXCEPT clearing interrupts.
     fn wait_until_ready(&self) {
         while !self.flc.ctrl().read().pend().bit_is_clear() {}
     }
 
     /// Clear any stale errors in the FLC Interrupt Register
-    /// 
+    ///
     /// This can be called without waiting for the FLC to be ready.
     fn clear_interrupts(&self) {
         self.flc.intr().modify(|_, w| w.af().clear_bit());
     }
 
     /// Prepares the FLC for a write operation.
-    /// 
+    ///
     /// Procedure:
     ///  - Wait until FLC ready
     ///  - Disable icc0
@@ -138,7 +138,11 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
     ///  - Lock write protection
     ///  - Flush ICC
     ///  - Enable icc0
-    fn write_guard<F: Fn() -> ()>(&self, sys_clk: &SystemClock, operation: F) -> Result<(), FlashErr> {
+    fn write_guard<F: Fn()>(
+        &self,
+        sys_clk: &SystemClock,
+        operation: F,
+    ) -> Result<(), FlashErr> {
         // Pre-write
         self.wait_until_ready();
         self.disable_icc0();
@@ -301,7 +305,12 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
 
     /// Writes less than 128 bits (16 bytes) of data to flash. Data needs to fit
     /// within one flash word (16 bytes).
-    unsafe fn write_lt_128_unaligned(&self, address: u32, data: &[u8], sys_clk: &SystemClock) -> Result<(), FlashErr> {
+    unsafe fn write_lt_128_unaligned(
+        &self,
+        address: u32,
+        data: &[u8],
+        sys_clk: &SystemClock,
+    ) -> Result<(), FlashErr> {
         // Get byte idx within 128-bit word
         let byte_idx = (address & 0xF) as usize;
 
@@ -327,7 +336,12 @@ impl<'gcr, 'icc> FlashController<'gcr, 'icc> {
     }
 
     /// Writes 128 bits (16 bytes) of data to flash.
-    unsafe fn write128(&self, address: u32, data: &[u32; 4], sys_clk: &SystemClock) -> Result<(), FlashErr> {
+    unsafe fn write128(
+        &self,
+        address: u32,
+        data: &[u32; 4],
+        sys_clk: &SystemClock,
+    ) -> Result<(), FlashErr> {
         // Check if adddress is 128-bit aligned
         if address & 0xF > 0 {
             return Err(FlashErr::AddressNotAligned128);

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -13,6 +13,8 @@ fn main() {
         .write_all(include_bytes!("memory.x"))
         .unwrap();
 
+    println!("cargo:rustc-link-arg=--nmagic");
+
     // Only re-run the build script when this file, memory.x, or link.x is changed.
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=memory.x");

--- a/tests/memory.x
+++ b/tests/memory.x
@@ -1,28 +1,9 @@
 MEMORY
 {
-    FLASH      (rx)  :  ORIGIN = 0x1000E000,                             LENGTH = 222K 
-    SECFLASH   (rx)  :  ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH),          LENGTH = 2K 
+    FLASH      (rx)  :  ORIGIN = 0x10000000,                             LENGTH = 512K
     STACK      (rw)  :  ORIGIN = 0x20000000,                             LENGTH = 110K
     RAM        (rw)  :  ORIGIN = ORIGIN(STACK) + LENGTH(STACK),          LENGTH = 128K - LENGTH(STACK)
 }
 
-/*
-Add a block of memory for the stack before the RAM block, so that a stack overflow leaks into
-reserved space and flash memory, instead of .data and .bss.
-*/
-ASSERT((LENGTH(SECFLASH) == 2K), "Error: SECFLASH is not 2K. To change the size, update this assert, the size in the MEMORY section, and the assert in the flash layout crate.") 
-
 _stack_start = ORIGIN(STACK) + LENGTH(STACK);
 _stack_end = ORIGIN(STACK);
-
-/* Bootloader hard jumps to 0x1000e200 */
-_stext = ORIGIN(FLASH) + 0x200;
-
-SECTIONS {
-    /* Add a section for the secure flash space. */
-    .secflash ORIGIN(SECFLASH) :
-    {
-        KEEP(*(.secflash .secflash.*));
-        . = ALIGN(4);
-    } > SECFLASH
-}

--- a/tests/memory.x
+++ b/tests/memory.x
@@ -1,6 +1,7 @@
 MEMORY
 {
-    FLASH      (rx)  :  ORIGIN = 0x10000000,                             LENGTH = 512K
+    FLASH      (rx)  :  ORIGIN = 0x1000E000,                             LENGTH = 222K 
+    SECFLASH   (rx)  :  ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH),          LENGTH = 2K 
     STACK      (rw)  :  ORIGIN = 0x20000000,                             LENGTH = 110K
     RAM        (rw)  :  ORIGIN = ORIGIN(STACK) + LENGTH(STACK),          LENGTH = 128K - LENGTH(STACK)
 }
@@ -9,5 +10,19 @@ MEMORY
 Add a block of memory for the stack before the RAM block, so that a stack overflow leaks into
 reserved space and flash memory, instead of .data and .bss.
 */
+ASSERT((LENGTH(SECFLASH) == 2K), "Error: SECFLASH is not 2K. To change the size, update this assert, the size in the MEMORY section, and the assert in the flash layout crate.") 
 
 _stack_start = ORIGIN(STACK) + LENGTH(STACK);
+_stack_end = ORIGIN(STACK);
+
+/* Bootloader hard jumps to 0x1000e200 */
+_stext = ORIGIN(FLASH) + 0x200;
+
+SECTIONS {
+    /* Add a section for the secure flash space. */
+    .secflash ORIGIN(SECFLASH) :
+    {
+        KEEP(*(.secflash .secflash.*));
+        . = ALIGN(4);
+    } > SECFLASH
+}

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -58,6 +58,26 @@ fn main() -> ! {
     .configure_timer_2(Oscillator::ISO, Prescaler::_4096)
     .build();
 
+    // run FLC tests with semi-hosting
+    flc_tests::run_flc_tests(
+        &mut stdout,
+        manager.flash_controller().unwrap(),
+        manager.system_clock().unwrap(),
+    );
+
+    {
+        let mut uart = manager.build_uart().unwrap().build(115200);
+
+        // run FLC tests with UART
+        flc_tests::run_flc_tests(
+            &mut uart,
+            manager.flash_controller().unwrap(),
+            manager.system_clock().unwrap(),
+        );
+
+        // UART instance is tossed here
+    }
+
     flc_tests::run_flc_tests(
         &mut stdout,
         manager.flash_controller().unwrap(),

--- a/tests/src/tests/flc_tests.rs
+++ b/tests/src/tests/flc_tests.rs
@@ -1,7 +1,6 @@
 //! Flash controller tests
 
 use core::fmt::Write;
-use cortex_m_semihosting::hio;
 use max78000_hal::peripherals::flash_controller::{FlashController, FlashErr};
 use max78000_hal::peripherals::oscillator::{
     Ibro, IbroDivider, IbroFrequency, Iso, IsoDivider, IsoFrequency, Oscillator, SystemClock,
@@ -14,8 +13,8 @@ use max78000_hal::peripherals::PeripheralHandle;
 /// [`flash_write_full_outbounds`],
 /// [`flash_write_partially_outbound_beginning`],
 /// [`flash_write_full_partially_outbound_end`].
-pub fn run_flc_tests(
-    stdout: &mut hio::HostStream,
+pub fn run_flc_tests<T: Write>(
+    stdout: &mut T,
     flash_controller: PeripheralHandle<'_, FlashController<'_, '_>>,
     mut sys_clk: PeripheralHandle<'_, SystemClock<'_, '_>>,
 ) {


### PR DESCRIPTION
Main Changes:
- [x] Added a new write_guard function which takes a closure to guarantee proper FLC pre/post write operations
- [x] Fix some code duplication to help reduce bugs (busy wait loop, clear interrupts)
- [x] Update tests to include both semihosting and UART